### PR TITLE
Add Not Human Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,4 @@ The list is organized as a timeline, containing software that support the follow
 | [2025-08-07](https://miromind.ai/blog/miromind-open-deep-research)                                                                                             | [MiroThinker](https://dr.miromind.ai/)                 |
 | [2025-08-25](https://www.instagram.com/p/DNGyGnYMLzr/)                                                                                                         | [YouTopia](https://youtopia.page/)                     |
 | [2026-01-27](https://www.yahooinc.com/press/introducing-yahoo-scout-a-new-ai-answer-engine)                                                                    | [Yahoo Scout](https://scout.yahoo.com/)                |
+| [2026-04-13](https://nothumansearch.ai/)                                                                                                                       | [Not Human Search](https://nothumansearch.ai/)         |


### PR DESCRIPTION
Add [Not Human Search](https://nothumansearch.ai/) to the Closed Source list.

Not Human Search is a search engine built for AI agents — it indexes 300+ tools and services ranked by agentic readiness. Features include a REST API, MCP server, OpenAPI spec, llms.txt, and ai-plugin.json for programmatic discovery by agents.