### PR TITLE
Add Crawlberg to Tools for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ Focused on general-purpose web search; domain-specific search APIs (academic pap
 | [2025-05-14](https://news.ycombinator.com/item?id=43986828)                                                       | [Tako](https://tako.com/)                                   | Search API      |
 | [2025-08-25](https://pypi.org/project/aisearchapi-client/#history)                                                | [AI Search API](https://aisearchapi.io/)                    | Search API      |
 | [2026-01-03](https://www.desearch.ai/blog/decentralized-search-engine-desearch-bittensor)                         | [Desearch](https://www.desearch.ai/web-search-api)          | Search API      |
-| [2026-03-09](https://github.com/xberg-io/crawlberg/commit/5a34a5a363174fe3476406e167f7a9be2ba2b6d0) | [crawlberg](https://github.com/xberg-io/crawlberg) | Scrape + Crawl |
+| [2026-03-09](https://github.com/xberg-io/crawlberg/commit/5a34a5a363174fe3476406e167f7a9be2ba2b6d0) | [Crawlberg](https://github.com/xberg-io/crawlberg) | Scrape + Crawl |

--- a/README.md
+++ b/README.md
@@ -160,3 +160,4 @@ Focused on general-purpose web search; domain-specific search APIs (academic pap
 | [2025-05-14](https://news.ycombinator.com/item?id=43986828)                                                       | [Tako](https://tako.com/)                                   | Search API      |
 | [2025-08-25](https://pypi.org/project/aisearchapi-client/#history)                                                | [AI Search API](https://aisearchapi.io/)                    | Search API      |
 | [2026-01-03](https://www.desearch.ai/blog/decentralized-search-engine-desearch-bittensor)                         | [Desearch](https://www.desearch.ai/web-search-api)          | Search API      |
+| [2026-03-09](https://github.com/xberg-io/crawlberg/commit/5a34a5a363174fe3476406e167f7a9be2ba2b6d0) | [crawlberg](https://github.com/xberg-io/crawlberg) | Scrape + Crawl |


### PR DESCRIPTION
Adds **crawlberg** (github.com/xberg-io/crawlberg, MIT) to **Tools for AI Agents** — an open-source web crawling & scraping building block for agents (scrape, crawl, map, interact) with HTML→Markdown output and a headless-Chrome fallback, offered as an MCP server. Sits alongside Jina and Firecrawl as a scrape/crawl primitive.
