### PR TITLE
Add Caesar to Open Source list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The list is organized as a timeline, containing software that support the follow
 | [2026-02-08](https://github.com/rupeshs/verity/commit/6f1acfe0be074e12272089fcdeee8215e426adab)                                      | [Verity](https://github.com/rupeshs/verity)                                                          | [Screenshot](https://raw.githubusercontent.com/rupeshs/verity/12954e3da84dda8c00e7c9487c1a35a3f4968906/docs/images/verity-screenshot.png)                                              |
 | [2026-02-10](https://github.com/chutesai/chutes-search/commit/bb5eafeec98e6caeabf78ad77a9d174992190272)                              | [Chutes Search](https://github.com/chutesai/chutes-search)                                           | [Homepage](https://search.chutes.ai/)                                                                                                                                                  |
 | [2026-03-04](https://github.com/tobocop2/lilbee/commit/d9f6ee936ab7ff79cc675ff260b931dbcc77fff8) | [lilbee](https://github.com/tobocop2/lilbee) | [Homepage](https://lilbee.sh) |
+| [2026-05-01](https://github.com/jasonzliang/caesar-agent/commit/e98f40b95d174091c32885dc290400495fbb6cda) | [Caesar](https://github.com/jasonzliang/caesar-agent) | [Homepage](https://jasonzliang.github.io/caesar-agent/) |
 
 ## Closed Source
 


### PR DESCRIPTION
Adds [Caesar](https://github.com/jasonzliang/caesar-agent) to **Open Source**, placed last to keep the table in initial-commit order (2026-05-01, after lilbee's 2026-03-04).

Caesar is an autonomous research agent: it traverses the web building a knowledge graph, choosing between depth-first expansion, backtracking and targeted search, then synthesizes an answer by re-reading each draft and challenging its own gaps before merging. Same neighbourhood as GPT Researcher and STORM, already listed here.

Apache-2.0, `pip install caesar-agent` ([PyPI](https://pypi.org/project/caesar-agent/) 0.4.17), paper [arXiv:2604.20855](https://arxiv.org/abs/2604.20855). Self-hosted; users bring their own LLM key.

I am the author. Happy to convert this to a suggestion issue instead if that is the route you prefer.