### PR TITLE
Add Context.dev to tools for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Focused on general-purpose web search; domain-specific search APIs (academic pap
 | [2025-08-25](https://pypi.org/project/aisearchapi-client/#history)                                                | [AI Search API](https://aisearchapi.io/)                    | Search API      |
 | [2026-01-03](https://www.desearch.ai/blog/decentralized-search-engine-desearch-bittensor)                         | [Desearch](https://www.desearch.ai/web-search-api)          | Search API      |
 | [2026-03-09](https://github.com/xberg-io/crawlberg/commit/5a34a5a363174fe3476406e167f7a9be2ba2b6d0) | [Crawlberg](https://github.com/xberg-io/crawlberg) | Scrape + Crawl |
+| [2026-03-14](https://github.com/context-dot-dev/context-typescript-sdk/commit/93d5d74b3fc50cba08ec297b3b3cf38ed6836dc7) | [Context.dev](https://www.context.dev/) | Scrape + Search |
 | [2026-05-28](https://www.24-7pressrelease.com/press-release/535286/talordata-launches-real-time-serp-api-for-ai-agents-seo-platforms-and-search-data-workflows) | [TalorData](https://www.talordata.com/) | SERP API        |
 | [2026-07-07](https://github.com/goofrey/zoom-search/releases/tag/v0.1.1) | [Zoom Search](https://github.com/goofrey/zoom-search) | Search + Answer |
 | [2026-08-07](https://github.com/querit-ai/querit-mcp/releases/tag/v0.1.0) | [Querit](https://www.querit.ai/en) | Search API |


### PR DESCRIPTION
## Summary

Adds Context.dev to the chronological Tools for AI Agents table as a search and scraping API.

The date links to the initial commit in the public Context.dev TypeScript SDK so the timeline entry has a verifiable source.

## Verification

- https://github.com/context-dot-dev/context-typescript-sdk/commit/93d5d74b3fc50cba08ec297b3b3cf38ed6836dc7
- https://docs.context.dev/

## Affiliation

I work at Context.dev.